### PR TITLE
Fix wait_for_file delay that was too short

### DIFF
--- a/util/file_util.py
+++ b/util/file_util.py
@@ -18,10 +18,10 @@ def mkdir_p(path):
         else:
             raise
 
-def wait_for_file_created_by_process(pid, file, timeout=5):
+def wait_for_file_created_by_process(pid, file, timeout=20):
     process = psutil.Process(pid)
 
-    DELAY = 0.05
+    DELAY = 1
     for i in range(int(timeout/DELAY)):
         if os.path.isfile(file):
             if file in process.open_files():


### PR DESCRIPTION
This resolves the problem I was having with BOM file not being created in https://github.com/obra/kicad-tools/issues/27.

The problem is that the loop delay was 0.05 seconds which I believe was consuming a lot of compute in a busy loop and not leaving enough time for the actual export process to complete. This is why I saw it as an intermittent error, which sometimes was helped by increasing the timeout. Changing the loop delay to 1 second allows the eeschema bom export to finish. I changed the overall timeout to 20 seconds because mine took 12 seconds to complete. 5 was not long enough.

I don't believe that this change would cause anyone else's build to break. But I only tested it on my own project.